### PR TITLE
fix(light & darkness): capitalize crucifiction

### DIFF
--- a/fp/en/cross/i18n/en-decorations.json
+++ b/fp/en/cross/i18n/en-decorations.json
@@ -84,8 +84,8 @@
   {
     "key": "challenge",
     "text": {
-      "original": "Take time for confession and develop a plan for repentance. Read Appendix B — The Medical Account of Jesus' crucifixion or watch the Cross Video.",
-      "translated": "Take time for confession and develop a plan for repentance. Read Appendix B — The Medical Account of Jesus' crucifixion or watch the Cross Video."
+      "original": "Take time for confession and develop a plan for repentance. Read Appendix B — The Medical Account of Jesus' Crucifixion or watch the Cross Video.",
+      "translated": "Take time for confession and develop a plan for repentance. Read Appendix B — The Medical Account of Jesus' Crucifixion or watch the Cross Video."
     },
     "decorations": {
       "bold": true
@@ -94,8 +94,8 @@
   {
     "key": "challenge",
     "text": {
-      "original": "The Medical Account of Jesus' crucifixion",
-      "translated": "The Medical Account of Jesus' crucifixion"
+      "original": "The Medical Account of Jesus' Crucifixion",
+      "translated": "The Medical Account of Jesus' Crucifixion"
     },
     "decorations": {
       "link": { "href": "../medical-account/", "attributes": "" }

--- a/fp/en/cross/i18n/en.json
+++ b/fp/en/cross/i18n/en.json
@@ -62,5 +62,5 @@
   "1-peter-2-21-24-description-1": "Jesus suffered for each of us individually.",
   "1-peter-2-21-24-description-2": "We must die to sin and live for righteousness.",
   "1-peter-2-21-24-description-3": "What is the hardest sin you need to surrender?",
-  "challenge": "Challenge: Die to sin and live for righteousness out of gratitude for the Cross. Are you more like Peter, Judas, or Pilate? Which response will you choose? Take time for confession and develop a plan for repentance. Read Appendix B — The Medical Account of Jesus' crucifixion or watch the Cross Video."
+  "challenge": "Challenge: Die to sin and live for righteousness out of gratitude for the Cross. Are you more like Peter, Judas, or Pilate? Which response will you choose? Take time for confession and develop a plan for repentance. Read Appendix B — The Medical Account of Jesus' Crucifixion or watch the Cross Video."
 }


### PR DESCRIPTION
This hopefully resolves #15.

I tried to modify the text to capitalize the 'C' of crucifixion in the Appendix B title. However, I'm not familiar with the way the project is structured where the content is contained inside a JSON instead of the HTML so there may be errors. This is the only spot in the Repo where I could find text matching the content of the study, so I'm hoping these are the right modifications.

I tried to verify with "Live Server," but the local server wouldn't update to any changes I would make, but displayed the fixed title, so I wasn't able to verify what the website looks like before my commit made changes.

